### PR TITLE
Keyword Extraction and Semantic Scholar Search/Save PDFs

### DIFF
--- a/backend/search.py
+++ b/backend/search.py
@@ -14,7 +14,8 @@ query = ""
 #QUERY BREAKDOWN/KEYWORD EXTRACTION
 ###################################
 
-openRouterAPIKey = "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"
+#fill API key here
+openRouterAPIKey = ""
 sentence_breakdown = requests.post(
   url="https://openrouter.ai/api/v1/chat/completions",
   headers={
@@ -76,6 +77,7 @@ if sentence_breakdown.status_code == 200:
     breakdown_json = json.loads(breakdown_data.get("choices")[0].get("message").get("content"))
 else:
     print(sentence_breakdown.status_code)
+    exit(1)
 
 subject_queries = breakdown_json.get("subject_queries")
 query_conditions = breakdown_json.get("query_conditions")
@@ -137,6 +139,7 @@ if keyword_breakdown.status_code == 200:
     keywords_json = json.loads(breakdown2_data.get("choices")[0].get("message").get("content"))
 else:
     print(keyword_breakdown.status_code)
+    exit(1)
 print(keywords_json)
 
 
@@ -166,8 +169,9 @@ query_params = {
 response = requests.get(url, params=query_params).json()['data']
 pdfs = [(i["openAccessPdf"]["url"], i["title"], i["year"], i["abstract"], i["publicationDate"], i["authors"]) for i in response if i.get("openAccessPdf")]
 
-def cleanName(name):
-    return re.sub(r'[<>:"/\\|?*]', '_', name)
+def cleanName(name, max_length=50):
+  cleaned = re.sub(r'[<>:"/\|?*]', '_', name)
+  return cleaned[:max_length]
 
 directory = r"C:\\Users\\fujii\Downloads\\519ProjectTesting\\Papers"
 


### PR DESCRIPTION
# Pull Request Template

## Title
Keyword Extraction and Semantic Scholar Search/Save PDFs

## Type of Change
- [ ] New feature


## Description
Keyword Extraction:
Uses OpenRouter DeepSeek-R1 to identify intention behind search queries, splitting search query phrases into subject queries and paper condition queries. Phrases are further split into keywords to be used for Semantic Scholar PDF search. 

Semantic Scholar Search:
Uses Semantic Scholar API to access PDFs based on Keyword Extraction. 3 papers are saved, if the papers are under valid, unobstructed links.

## Testing
Tested the Keyword Extraction on varying queries generated by ChatGPT about a variety of subjects in a variety of sentence structures.

Extracted Keywords were passed to Search.

## Impact
This is the search and save feature that allows our bot to access new PDFs and build its knowledge.

## Additional Information
This needs an OpenRouter API key. Unpaid models are significantly worse at keyword extraction. Semantic Scholar also has limitations in the open PDFs it provides, and they have stopped providing API keys.

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings 
